### PR TITLE
Fixed error that caused page load fail

### DIFF
--- a/src/app/libs/getLeaderboardData.js
+++ b/src/app/libs/getLeaderboardData.js
@@ -112,6 +112,15 @@ export default async function getLeaderboardData() {
 
     await Promise.all(leaderboardUpdates);
 
+    // Add sorting logic here
+    const tierOrder = ["challenger", "grandmaster", "master"];
+    sortedLeaderboards.sort((a, b) => {
+      if (tierOrder.indexOf(a.tier) !== tierOrder.indexOf(b.tier)) {
+        return tierOrder.indexOf(a.tier) - tierOrder.indexOf(b.tier);
+      }
+      return b.leaguePoints - a.leaguePoints;
+    });
+
     return sortedLeaderboards.map((entry) => ({
       ...entry,
       tagLine: entry.tagLine,


### PR DESCRIPTION
- Added parallel fetching for all tiers and updated the database query so that the database is queried once for all existing summonerIds to minimize individual lookups.
- Added sorting logic before returning the final leaderboards to sort by tier and then league points.